### PR TITLE
Allow Laravel 13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,12 +22,12 @@
     "require": {
         "php": "8.2.*|8.3.*|8.4.*|8.5.*",
         "ext-pdo": "*",
-        "illuminate/support": "^12.0",
-        "illuminate/database": "^12.0"
+        "illuminate/support": "^12.0|^13.0",
+        "illuminate/database": "^12.0|^13.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.69",
-        "orchestra/testbench": "^10.0",
+        "orchestra/testbench": "^10.0|^11.0",
         "phpunit/phpunit": "^11.5"
     },
     "autoload": {


### PR DESCRIPTION
Adds support for Laravel 13 by widening the `illuminate/support` and `illuminate/database` constraints to `^12.0|^13.0` (and `orchestra/testbench` to `^10.0|^11.0`). The package already declares PHP 8.5 support and contains no framework-version-specific code, so no further changes are required.