### PR TITLE
Allow Laravel 13

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -13,11 +13,17 @@ jobs:
       fail-fast: false
       matrix:
         php: [ '8.2', '8.3', '8.4', '8.5' ]
-        laravel: [ 12.* ]
+        laravel: [ 12.*, 13.* ]
         dependency-version: [ prefer-stable ]
         include:
           - laravel: 12.*
             testbench: ^10.0
+          - laravel: 13.*
+            testbench: ^11.0
+        exclude:
+          # Laravel 13 requires PHP 8.3+.
+          - php: '8.2'
+            laravel: 13.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ For other database engines (for instance [MS SQL Server](https://learn.microsoft
 
 ### Installation
 
-For Laravel <=11, use version 4.0. For Laravel 12, use version 5.0.
+For Laravel <=11, use version 4.0. For Laravel 12 and 13, use version 5.0.
 
 ```
 composer require dbt/odbc-driver

--- a/composer.json
+++ b/composer.json
@@ -22,12 +22,12 @@
     "require": {
         "php": "8.2.*|8.3.*|8.4.*|8.5.*",
         "ext-pdo": "*",
-        "illuminate/support": "^12.0",
-        "illuminate/database": "^12.0"
+        "illuminate/support": "^12.0|^13.0",
+        "illuminate/database": "^12.0|^13.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.69",
-        "orchestra/testbench": "^10.0",
+        "orchestra/testbench": "^10.0|^11.0",
         "phpunit/phpunit": "^11.5"
     },
     "autoload": {


### PR DESCRIPTION
Adds Laravel 13 support.

Combines the changes from #46 (by @Team-Nifty-GmbH) with the missing CI coverage and docs:

- Widen `illuminate/support` and `illuminate/database` constraints to `^12.0|^13.0`, and `orchestra/testbench` to `^10.0|^11.0` (from #46).
- Add Laravel 13 (`testbench ^11.0`) to the CI matrix. Excludes `PHP 8.2 × Laravel 13` since Laravel 13 requires PHP 8.3+.
- Update README to note version 5.0 supports Laravel 12 and 13.

Supersedes #46.